### PR TITLE
feat(frontend): Add authentication and check-ins API client (#56)

### DIFF
--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Setup mock functions using vi.hoisted to avoid hoisting issues
+const { mockPost, mockGet } = vi.hoisted(() => ({
+  mockPost: vi.fn(),
+  mockGet: vi.fn(),
+}));
+
+// Mock axios module
+vi.mock('axios', () => {
+  return {
+    default: {
+      create: vi.fn(() => ({
+        post: mockPost,
+        get: mockGet,
+        interceptors: {
+          request: { use: vi.fn() },
+          response: { use: vi.fn() },
+        },
+      })),
+    },
+  };
+});
+
+import { authApi, checkInsApi } from '../api';
+
+describe('API Client', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  describe('authApi', () => {
+    describe('register', () => {
+      it('should successfully register a new user', async () => {
+        const mockResponse = {
+          data: {
+            success: true,
+            data: {
+              user: {
+                id: '123',
+                username: 'testuser',
+                email: 'test@example.com',
+                notificationTimes: ['08:00', '14:00', '20:00'],
+                notificationsEnabled: true,
+                createdAt: '2024-01-01T00:00:00.000Z',
+              },
+              token: 'mock-jwt-token',
+            },
+          },
+        };
+
+        mockPost.mockResolvedValue(mockResponse);
+
+        const result = await authApi.register({
+          username: 'testuser',
+          email: 'test@example.com',
+          password: 'Password123',
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.data.user.username).toBe('testuser');
+        expect(result.data.token).toBe('mock-jwt-token');
+      });
+    });
+
+    describe('login', () => {
+      it('should successfully login a user', async () => {
+        const mockResponse = {
+          data: {
+            success: true,
+            data: {
+              user: {
+                id: '123',
+                username: 'testuser',
+                email: 'test@example.com',
+                notificationTimes: ['08:00', '14:00', '20:00'],
+                notificationsEnabled: true,
+                createdAt: '2024-01-01T00:00:00.000Z',
+              },
+              token: 'mock-jwt-token',
+            },
+          },
+        };
+
+        mockPost.mockResolvedValue(mockResponse);
+
+        const result = await authApi.login({
+          email: 'test@example.com',
+          password: 'Password123',
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.data.user.email).toBe('test@example.com');
+        expect(result.data.token).toBe('mock-jwt-token');
+      });
+    });
+
+    describe('logout', () => {
+      it('should logout and clear localStorage', async () => {
+        localStorage.setItem('token', 'mock-token');
+        localStorage.setItem('user', JSON.stringify({ id: '123' }));
+
+        mockPost.mockResolvedValue({ data: { success: true } });
+
+        await authApi.logout();
+
+        expect(localStorage.getItem('token')).toBeNull();
+        expect(localStorage.getItem('user')).toBeNull();
+      });
+    });
+  });
+
+  describe('checkInsApi', () => {
+    describe('getAll', () => {
+      it('should fetch all check-ins', async () => {
+        const mockResponse = {
+          data: {
+            success: true,
+            data: {
+              checkIns: [
+                {
+                  _id: '1',
+                  userId: '123',
+                  timestamp: '2024-01-01T12:00:00.000Z',
+                  structured: {
+                    symptoms: { pain: 5 },
+                    activities: [],
+                    triggers: [],
+                    notes: '',
+                  },
+                  flaggedForDoctor: false,
+                  createdAt: '2024-01-01T12:00:00.000Z',
+                  updatedAt: '2024-01-01T12:00:00.000Z',
+                },
+              ],
+              pagination: {
+                total: 1,
+                limit: 20,
+                offset: 0,
+                hasMore: false,
+              },
+            },
+          },
+        };
+
+        mockGet.mockResolvedValue(mockResponse);
+
+        const result = await checkInsApi.getAll();
+
+        expect(result.success).toBe(true);
+        expect(result.data.checkIns).toHaveLength(1);
+        expect(result.data.pagination.total).toBe(1);
+      });
+
+      it('should pass query parameters', async () => {
+        const mockResponse = {
+          data: {
+            success: true,
+            data: {
+              checkIns: [],
+              pagination: { total: 0, limit: 20, offset: 0, hasMore: false },
+            },
+          },
+        };
+
+        mockGet.mockResolvedValue(mockResponse);
+
+        await checkInsApi.getAll({
+          startDate: '2024-01-01',
+          endDate: '2024-01-31',
+          symptom: 'pain',
+        });
+
+        expect(mockGet).toHaveBeenCalledWith('/checkins', {
+          params: {
+            startDate: '2024-01-01',
+            endDate: '2024-01-31',
+            symptom: 'pain',
+          },
+        });
+      });
+    });
+
+    describe('createVoice', () => {
+      it('should upload voice check-in', async () => {
+        const mockResponse = {
+          data: {
+            success: true,
+            data: {
+              checkIn: {
+                _id: '1',
+                userId: '123',
+                timestamp: '2024-01-01T12:00:00.000Z',
+                rawTranscript: 'test transcript',
+                structured: {
+                  symptoms: { pain: 5 },
+                  activities: [],
+                  triggers: [],
+                  notes: 'test transcript',
+                },
+                flaggedForDoctor: false,
+                createdAt: '2024-01-01T12:00:00.000Z',
+                updatedAt: '2024-01-01T12:00:00.000Z',
+              },
+            },
+          },
+        };
+
+        mockPost.mockResolvedValue(mockResponse);
+
+        const mockFile = new File(['audio'], 'test.webm', { type: 'audio/webm' });
+        const result = await checkInsApi.createVoice(mockFile);
+
+        expect(result.success).toBe(true);
+        expect(result.data.checkIn.rawTranscript).toBe('test transcript');
+      });
+    });
+
+    describe('createManual', () => {
+      it('should create manual check-in', async () => {
+        const mockResponse = {
+          data: {
+            success: true,
+            data: {
+              checkIn: {
+                _id: '1',
+                userId: '123',
+                timestamp: '2024-01-01T12:00:00.000Z',
+                structured: {
+                  symptoms: { pain: 7 },
+                  activities: ['walking'],
+                  triggers: ['stress'],
+                  notes: 'test notes',
+                },
+                flaggedForDoctor: false,
+                createdAt: '2024-01-01T12:00:00.000Z',
+                updatedAt: '2024-01-01T12:00:00.000Z',
+              },
+            },
+          },
+        };
+
+        mockPost.mockResolvedValue(mockResponse);
+
+        const result = await checkInsApi.createManual({
+          structured: {
+            symptoms: { pain: 7 },
+            activities: ['walking'],
+            triggers: ['stress'],
+            notes: 'test notes',
+          },
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.data.checkIn.structured.symptoms.pain).toBe(7);
+      });
+    });
+  });
+});

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,0 +1,161 @@
+import axios, { AxiosInstance, AxiosError } from 'axios';
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000/api';
+
+// Create axios instance with base configuration
+const apiClient: AxiosInstance = axios.create({
+  baseURL: API_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+// Request interceptor to add auth token
+apiClient.interceptors.request.use(
+  (config) => {
+    const token = localStorage.getItem('token');
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
+// Response interceptor for error handling
+apiClient.interceptors.response.use(
+  (response) => response,
+  (error: AxiosError) => {
+    if (error.response?.status === 401) {
+      // Clear token and redirect to login on unauthorized
+      localStorage.removeItem('token');
+      localStorage.removeItem('user');
+      window.location.href = '/login';
+    }
+    return Promise.reject(error);
+  }
+);
+
+// Types
+export interface User {
+  id: string;
+  username: string;
+  email: string;
+  notificationTimes: string[];
+  notificationsEnabled: boolean;
+  createdAt: string;
+}
+
+export interface AuthResponse {
+  success: boolean;
+  data: {
+    user: User;
+    token: string;
+  };
+}
+
+export interface CheckIn {
+  _id: string;
+  userId: string;
+  timestamp: string;
+  rawTranscript?: string;
+  structured: {
+    symptoms: Record<string, string | number | boolean>;
+    activities: string[];
+    triggers: string[];
+    notes: string;
+  };
+  flaggedForDoctor: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CheckInsResponse {
+  success: boolean;
+  data: {
+    checkIns: CheckIn[];
+    pagination: {
+      total: number;
+      limit: number;
+      offset: number;
+      hasMore: boolean;
+    };
+  };
+}
+
+export interface CheckInResponse {
+  success: boolean;
+  data: {
+    checkIn: CheckIn;
+  };
+}
+
+export interface ErrorResponse {
+  success: false;
+  error: string;
+}
+
+// Auth API
+export const authApi = {
+  register: async (data: {
+    username: string;
+    email: string;
+    password: string;
+  }): Promise<AuthResponse> => {
+    const response = await apiClient.post<AuthResponse>('/auth/register', data);
+    return response.data;
+  },
+
+  login: async (data: { email: string; password: string }): Promise<AuthResponse> => {
+    const response = await apiClient.post<AuthResponse>('/auth/login', data);
+    return response.data;
+  },
+
+  logout: async (): Promise<void> => {
+    await apiClient.post('/auth/logout');
+    localStorage.removeItem('token');
+    localStorage.removeItem('user');
+  },
+};
+
+// Check-ins API
+export const checkInsApi = {
+  getAll: async (params?: {
+    startDate?: string;
+    endDate?: string;
+    symptom?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<CheckInsResponse> => {
+    const response = await apiClient.get<CheckInsResponse>('/checkins', { params });
+    return response.data;
+  },
+
+  createVoice: async (audioFile: File): Promise<CheckInResponse> => {
+    const formData = new FormData();
+    formData.append('audio', audioFile);
+
+    const response = await apiClient.post<CheckInResponse>('/checkins', formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
+    return response.data;
+  },
+
+  createManual: async (data: {
+    structured: {
+      symptoms: Record<string, string | number | boolean>;
+      activities: string[];
+      triggers: string[];
+      notes: string;
+    };
+  }): Promise<CheckInResponse> => {
+    const response = await apiClient.post<CheckInResponse>('/checkins/manual', data);
+    return response.data;
+  },
+};
+
+export default apiClient;

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_URL: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- Implements axios-based API client service for backend communication
- Authentication API methods (register, login, logout)
- Check-ins API methods (getAll, createVoice, createManual)
- Request interceptor for JWT token injection from localStorage
- Response interceptor for 401 handling with auto-logout and redirect
- TypeScript interfaces for all request/response types
- Comprehensive test coverage with vitest (7/7 passing tests)

## Test plan
- [x] TypeScript compilation passes
- [x] ESLint passes with no warnings
- [x] All tests pass (7/7)
- [x] Auth API tests (register, login, logout)
- [x] Check-ins API tests (getAll, createVoice, createManual)

Closes #56