### PR TITLE
Fix: Clamp symptom severity values to valid range [1-10]

### DIFF
--- a/backend/src/services/parsingService.ts
+++ b/backend/src/services/parsingService.ts
@@ -137,7 +137,9 @@ Output: {
     const symptoms: { [key: string]: SymptomValue } = {};
     if (Array.isArray(parsed.symptoms)) {
       for (const symptom of parsed.symptoms) {
-        const symptomValue: SymptomValue = { severity: symptom.severity };
+        // Clamp severity to valid range [1, 10] in case GPT returns invalid values
+        const clampedSeverity = Math.min(10, Math.max(1, symptom.severity));
+        const symptomValue: SymptomValue = { severity: clampedSeverity };
         if (symptom.location) symptomValue.location = symptom.location;
         if (symptom.notes) symptomValue.notes = symptom.notes;
         symptoms[symptom.name] = symptomValue;


### PR DESCRIPTION
## Summary
- Fixed 500 error from iPhone 8 voice submission where GPT-4o-mini returned severity value < 1
- Added severity clamping to ensure all values fall within [1-10] range before database save
- Prevents Mongoose validation errors when GPT returns invalid severity values

## Root Cause
GPT-4o-mini occasionally returns severity values outside the valid range (e.g., 0 or negative values), causing Mongoose validation to fail with:
```
CheckIn validation failed: structured.symptoms.migraine.severity: Severity must be at least 1
```

## Changes
**backend/src/services/parsingService.ts:141**
- Added `Math.min(10, Math.max(1, symptom.severity))` clamping logic
- Ensures all severity values are within [1-10] before creating SymptomValue objects

**backend/src/services/__tests__/parsingService.test.ts:244-295**
- Added comprehensive test for severity clamping behavior
- Tests values below minimum (0 → 1), above maximum (15 → 10), and within range (5 → 5)

## Test Results
- ✅ All 335 backend tests passing
- ✅ 99.53% coverage maintained
- ✅ New test specifically validates clamping logic

## Impact
- Fixes production 500 errors from voice check-ins
- No breaking changes - backward compatible
- Defensive coding against GPT model variations