### PR TITLE
fix(ui): Prevent Safari iOS auto-zoom on input focus

### DIFF
--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -96,8 +96,8 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
 
     // Size styles
     const sizeStyles = {
-      small: 'px-3 py-1.5 text-sm',
-      medium: 'px-3 py-2 text-sm',
+      small: 'px-3 py-1.5 text-base',
+      medium: 'px-3 py-2 text-base',
       large: 'px-4 py-3 text-base',
     };
 


### PR DESCRIPTION
## Summary
- Changes Input component font size from `text-sm` (14px) to `text-base` (16px) for all sizes
- Prevents Safari iOS from auto-zooming when focusing on input fields
- Improves accessibility (WCAG recommends 16px minimum for body text)

## Problem
iOS Safari automatically zooms pages when input fields have font-size < 16px, causing horizontal scrollbars and poor mobile UX on iPhone 8 and other iOS devices.

## Solution
Updated `sizeStyles` in Input component:
```tsx
const sizeStyles = {
  small: 'px-3 py-1.5 text-base',   // 16px - prevents auto-zoom ✅
  medium: 'px-3 py-2 text-base',    // 16px - prevents auto-zoom ✅
  large: 'px-4 py-3 text-base',     // 16px - already correct ✅
};
```

## Testing
- [x] TypeScript typecheck passed
- [x] ESLint passed with 0 warnings
- [x] All 507 tests passed
- [x] Build successful
- [ ] Manual test on iPhone 8 Safari (requires user verification)

## Impact
- **Visual**: Input text 2px larger (14px → 16px)
- **Accessibility**: ✅ Improved (meets WCAG 16px recommendation)
- **Mobile UX**: ✅ No more unwanted zoom on iOS
- **Breaking Changes**: None

Fixes #154