### PR TITLE
feat: Format symptom and activity names for display

### DIFF
--- a/frontend/src/components/CheckInCard.tsx
+++ b/frontend/src/components/CheckInCard.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Card, Badge, Button, ConfirmDialog } from './ui';
 import { CheckIn, SymptomValue } from '../services/api';
 import { cn } from '../utils/cn';
+import { formatDisplayName } from '../utils/string';
 import type { BadgeProps } from './ui/Badge';
 
 interface CheckInCardProps {
@@ -103,7 +104,7 @@ export const CheckInCard: React.FC<CheckInCardProps> = ({
 
     // Fallback: show symptom names if available
     if (symptoms.length > 0) {
-      const symptomNames = symptoms.map(([name]) => name).slice(0, 3);
+      const symptomNames = symptoms.map(([name]) => formatDisplayName(name)).slice(0, 3);
       const text = symptomNames.join(', ');
       return symptoms.length > 3 ? `${text}, +${symptoms.length - 3} more` : text;
     }
@@ -209,8 +210,8 @@ export const CheckInCard: React.FC<CheckInCardProps> = ({
                         <div
                           key={symptom}
                           className={cn('w-3 h-3 rounded-full', bgColor)}
-                          title={`${symptom}: ${severity} (${getSeverityLabel(severity)})`}
-                          aria-label={`${symptom} severity ${severity}`}
+                          title={`${formatDisplayName(symptom)}: ${severity} (${getSeverityLabel(severity)})`}
+                          aria-label={`${formatDisplayName(symptom)} severity ${severity}`}
                         />
                       );
                     })}
@@ -325,9 +326,9 @@ export const CheckInCard: React.FC<CheckInCardProps> = ({
                   <Badge
                     key={symptom}
                     variant={getSeverityVariant(value.severity)}
-                    aria-label={`${symptom} ${getSeverityLabel(value.severity)} ${value.severity}`}
+                    aria-label={`${formatDisplayName(symptom)} ${getSeverityLabel(value.severity)} ${value.severity}`}
                   >
-                    {symptom}: {value.severity}
+                    {formatDisplayName(symptom)}: {value.severity}
                     {value.location && ` (${value.location})`}
                   </Badge>
                 ))}
@@ -344,7 +345,7 @@ export const CheckInCard: React.FC<CheckInCardProps> = ({
               <div className="flex flex-wrap gap-2">
                 {checkIn.structured.activities.map((activity) => (
                   <Badge key={activity} variant="success">
-                    {activity}
+                    {formatDisplayName(activity)}
                   </Badge>
                 ))}
               </div>
@@ -360,7 +361,7 @@ export const CheckInCard: React.FC<CheckInCardProps> = ({
               <div className="flex flex-wrap gap-2">
                 {checkIn.structured.triggers.map((trigger) => (
                   <Badge key={trigger} variant="error">
-                    {trigger}
+                    {formatDisplayName(trigger)}
                   </Badge>
                 ))}
               </div>
@@ -390,7 +391,7 @@ export const CheckInCard: React.FC<CheckInCardProps> = ({
                   .filter(([, value]) => value.notes)
                   .map(([symptom, value]) => (
                     <p key={symptom} className="text-sm text-gray-600">
-                      <span className="font-medium">{symptom}:</span>{' '}
+                      <span className="font-medium">{formatDisplayName(symptom)}:</span>{' '}
                       {value.notes}
                     </p>
                   ))}

--- a/frontend/src/components/CheckInGuidance.tsx
+++ b/frontend/src/components/CheckInGuidance.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { checkInsApi, CheckInContext } from '../services/api';
 import { Button } from './ui/Button';
+import { formatDisplayName } from '../utils/string';
 
 interface CheckInGuidanceProps {
   className?: string;
@@ -165,7 +166,7 @@ export default function CheckInGuidance({
                         key={symptom.name}
                         className="inline-flex items-center px-3 py-1.5 rounded-full text-sm font-medium bg-blue-50 text-blue-700 border border-blue-100"
                       >
-                        {symptom.name} <span className="ml-1 text-blue-500">{symptom.severity}/10</span>
+                        {formatDisplayName(symptom.name)} <span className="ml-1 text-blue-500">{symptom.severity}/10</span>
                       </span>
                     ))}
                     {context.lastCheckIn.symptoms.length > 5 && (
@@ -196,7 +197,7 @@ export default function CheckInGuidance({
                       key={symptom.name}
                       className={`inline-flex items-center px-3 py-1.5 rounded-full text-sm font-medium border ${getTrendStyles(symptom.trend)}`}
                     >
-                      {symptom.name}
+                      {formatDisplayName(symptom.name)}
                       <span className="ml-1.5">{getTrendIcon(symptom.trend)}</span>
                     </span>
                   ))}

--- a/frontend/src/components/HealthSummary.tsx
+++ b/frontend/src/components/HealthSummary.tsx
@@ -1,6 +1,7 @@
 import { TrendingDown, TrendingUp, Minus } from 'lucide-react';
 import { Card } from './ui/Card';
 import { cn } from '../utils/cn';
+import { formatDisplayName } from '../utils/string';
 
 export interface TopSymptom {
   name: string;
@@ -126,7 +127,7 @@ export function HealthSummary({
                   key={symptom.name}
                   className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-gray-100 rounded-full text-sm text-gray-700"
                 >
-                  <span className="capitalize">{symptom.name}</span>
+                  <span>{formatDisplayName(symptom.name)}</span>
                   {symptom.avgSeverity !== null && (
                     <span className="text-gray-500">({symptom.avgSeverity.toFixed(1)})</span>
                   )}

--- a/frontend/src/components/LatestVsAverage.tsx
+++ b/frontend/src/components/LatestVsAverage.tsx
@@ -1,7 +1,7 @@
 import { ArrowUp, ArrowDown, Equal, type LucideIcon } from 'lucide-react';
 import { Card } from './ui/Card';
 import { cn } from '../utils/cn';
-import { capitalize, formatNumber } from '../utils/string';
+import { formatDisplayName, formatNumber } from '../utils/string';
 
 // Types
 export type TrendDirection = 'above' | 'below' | 'equal';
@@ -61,7 +61,7 @@ function SymptomComparisonCard({ symptom }: SymptomComparisonCardProps) {
     <div className={cn('rounded-lg p-4', bgColor)}>
       <div className="flex items-center justify-between">
         <div>
-          <p className="font-semibold text-gray-900">{capitalize(symptom.name)}</p>
+          <p className="font-semibold text-gray-900">{formatDisplayName(symptom.name)}</p>
           <p className="text-sm text-gray-600">
             Now: <span className="font-medium">{formatNumber(symptom.latestValue)}</span>
             {' · '}

--- a/frontend/src/components/__tests__/CheckInCard.test.tsx
+++ b/frontend/src/components/__tests__/CheckInCard.test.tsx
@@ -226,9 +226,9 @@ describe('CheckInCard', () => {
 
       render(<CheckInCard checkIn={checkIn} mode="expanded" />);
 
-      expect(screen.getByText('headache: 8')).toBeInTheDocument();
-      expect(screen.getByText('fatigue: 5')).toBeInTheDocument();
-      expect(screen.getByText('nausea: 3')).toBeInTheDocument();
+      expect(screen.getByText('Headache: 8')).toBeInTheDocument();
+      expect(screen.getByText('Fatigue: 5')).toBeInTheDocument();
+      expect(screen.getByText('Nausea: 3')).toBeInTheDocument();
     });
 
     it('displays symptom location when available', () => {
@@ -269,15 +269,15 @@ describe('CheckInCard', () => {
       const checkIn = createMockCheckIn();
       render(<CheckInCard checkIn={checkIn} mode="expanded" />);
 
-      expect(screen.getByText('walking')).toBeInTheDocument();
-      expect(screen.getByText('reading')).toBeInTheDocument();
+      expect(screen.getByText('Walking')).toBeInTheDocument();
+      expect(screen.getByText('Reading')).toBeInTheDocument();
     });
 
     it('displays triggers with error badges', () => {
       const checkIn = createMockCheckIn();
       render(<CheckInCard checkIn={checkIn} mode="expanded" />);
 
-      expect(screen.getByText('stress')).toBeInTheDocument();
+      expect(screen.getByText('Stress')).toBeInTheDocument();
     });
 
     it('displays full notes', () => {
@@ -509,7 +509,7 @@ describe('CheckInCard', () => {
 
       const { container } = render(<CheckInCard checkIn={checkIn} />);
 
-      const dot = container.querySelector('[aria-label*="headache severity"]');
+      const dot = container.querySelector('[aria-label*="Headache severity"]');
       expect(dot).toBeInTheDocument();
     });
 

--- a/frontend/src/pages/TrendsPage.tsx
+++ b/frontend/src/pages/TrendsPage.tsx
@@ -8,6 +8,7 @@ import { Card } from '../components/ui/Card';
 import { SymptomChart } from '../components/charts/SymptomChart';
 import { QuickStatsCard } from '../components/dashboard/QuickStatsCard';
 import { Header } from '../components/Header';
+import { formatDisplayName } from '../utils/string';
 
 export default function TrendsPage() {
   const navigate = useNavigate();
@@ -179,7 +180,7 @@ export default function TrendsPage() {
                     >
                       {symptoms.map((symptom) => (
                         <option key={symptom.name} value={symptom.name}>
-                          {symptom.name} {symptom.average !== undefined ? `(avg: ${symptom.average.toFixed(1)})` : ''}
+                          {formatDisplayName(symptom.name)} {symptom.average !== undefined ? `(avg: ${symptom.average.toFixed(1)})` : ''}
                         </option>
                       ))}
                     </select>
@@ -224,11 +225,11 @@ export default function TrendsPage() {
                 <>
                   <Card variant="default" padding="default">
                     <h3 className="text-lg font-semibold text-gray-900 mb-4">
-                      {selectedSymptom} - Severity Over Time
+                      {formatDisplayName(selectedSymptom)} - Severity Over Time
                     </h3>
                     <SymptomChart
                       data={trendData.dataPoints}
-                      symptomName={selectedSymptom}
+                      symptomName={formatDisplayName(selectedSymptom)}
                       dateRange={trendData.dateRange}
                       onDateClick={(date) => {
                         console.log('Clicked date:', date);

--- a/frontend/src/utils/string.ts
+++ b/frontend/src/utils/string.ts
@@ -28,3 +28,20 @@ export function getInitial(str: string | undefined | null, fallback: string = 'U
 export function formatNumber(value: number, decimals: number = 1): string {
   return value.toFixed(decimals);
 }
+
+/**
+ * Format a snake_case or underscore-separated string for display
+ * Converts to Title Case with spaces
+ * @example formatDisplayName('joint_pain') => 'Joint Pain'
+ * @example formatDisplayName('back_pain') => 'Back Pain'
+ * @example formatDisplayName('headache') => 'Headache'
+ * @example formatDisplayName('Back Pain') => 'Back Pain' (preserves already-formatted)
+ */
+export function formatDisplayName(str: string): string {
+  if (!str) return '';
+  // Split on underscores or spaces, then title case each word
+  return str
+    .split(/[_\s]+/)
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ');
+}


### PR DESCRIPTION
## Summary
- Add `formatDisplayName()` utility to convert `snake_case` names to Title Case
- Apply formatting across all UI components that display symptoms, activities, and triggers
- Improves readability: `joint_pain` → `Joint Pain`

## Changes
- `src/utils/string.ts` - New utility function
- `CheckInCard.tsx` - Symptoms, activities, triggers badges
- `CheckInGuidance.tsx` - Recent symptoms display
- `HealthSummary.tsx` - Top concerns
- `LatestVsAverage.tsx` - Symptom comparisons
- `TrendsPage.tsx` - Symptom selector and chart title

## Test plan
- [x] All 633 tests pass
- [x] Lint passes
- [x] Typecheck passes
- [x] Verify `joint_pain` displays as `Joint Pain`
- [x] Verify `headache` displays as `Headache`