### PR TITLE
Add user registration and check-in reporting system

### DIFF
--- a/backend/src/config/passport.ts
+++ b/backend/src/config/passport.ts
@@ -37,6 +37,7 @@ passport.use(
         id: String(user._id),
         username: user.username,
         email: user.email,
+        isAdmin: user.isAdmin,
       });
     } catch (error) {
       logger.error('Error in JWT strategy', { error });

--- a/backend/src/controllers/__tests__/reportingController.test.ts
+++ b/backend/src/controllers/__tests__/reportingController.test.ts
@@ -1,0 +1,345 @@
+import { Request, Response, NextFunction } from 'express';
+import { getAdminStats, getMyStats } from '../reportingController';
+import * as reportingService from '../../services/reportingService';
+
+// Mock the reporting service
+jest.mock('../../services/reportingService');
+
+describe('Reporting Controller', () => {
+  let mockReq: Partial<Request>;
+  let mockRes: Partial<Response>;
+  let mockNext: NextFunction;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockReq = {
+      user: undefined,
+    };
+
+    mockRes = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+
+    mockNext = jest.fn();
+  });
+
+  describe('getAdminStats', () => {
+    it('should return admin statistics successfully', async () => {
+      // Arrange
+      const mockStats = {
+        totalUsers: 10,
+        totalCheckIns: 150,
+        users: [
+          {
+            userId: '507f1f77bcf86cd799439011',
+            username: 'user1',
+            email: 'user1@example.com',
+            checkInCount: 50,
+            lastCheckIn: new Date('2024-12-01'),
+            registeredAt: new Date('2024-01-01'),
+          },
+          {
+            userId: '507f1f77bcf86cd799439012',
+            username: 'user2',
+            email: 'user2@example.com',
+            checkInCount: 100,
+            lastCheckIn: new Date('2024-12-05'),
+            registeredAt: new Date('2024-01-15'),
+          },
+        ],
+      };
+
+      (reportingService.getAllUsersStats as jest.Mock).mockResolvedValue(mockStats);
+
+      // Act
+      await getAdminStats(mockReq as Request, mockRes as Response, mockNext);
+
+      // Assert
+      expect(reportingService.getAllUsersStats).toHaveBeenCalledTimes(1);
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        success: true,
+        data: mockStats,
+      });
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('should return empty statistics when no users exist', async () => {
+      // Arrange
+      const mockEmptyStats = {
+        totalUsers: 0,
+        totalCheckIns: 0,
+        users: [],
+      };
+
+      (reportingService.getAllUsersStats as jest.Mock).mockResolvedValue(mockEmptyStats);
+
+      // Act
+      await getAdminStats(mockReq as Request, mockRes as Response, mockNext);
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        success: true,
+        data: mockEmptyStats,
+      });
+    });
+
+    it('should handle service errors and call next', async () => {
+      // Arrange
+      const error = new Error('Database connection failed');
+      (reportingService.getAllUsersStats as jest.Mock).mockRejectedValue(error);
+
+      // Act
+      await getAdminStats(mockReq as Request, mockRes as Response, mockNext);
+
+      // Assert
+      expect(reportingService.getAllUsersStats).toHaveBeenCalledTimes(1);
+      expect(mockNext).toHaveBeenCalledWith(error);
+      expect(mockRes.status).not.toHaveBeenCalled();
+      expect(mockRes.json).not.toHaveBeenCalled();
+    });
+
+    it('should handle unexpected service errors', async () => {
+      // Arrange
+      const error = new Error('Unexpected error occurred');
+      (reportingService.getAllUsersStats as jest.Mock).mockRejectedValue(error);
+
+      // Act
+      await getAdminStats(mockReq as Request, mockRes as Response, mockNext);
+
+      // Assert
+      expect(mockNext).toHaveBeenCalledWith(error);
+    });
+
+    it('should return stats with users that have no check-ins', async () => {
+      // Arrange
+      const mockStats = {
+        totalUsers: 2,
+        totalCheckIns: 5,
+        users: [
+          {
+            userId: '507f1f77bcf86cd799439011',
+            username: 'activeuser',
+            email: 'active@example.com',
+            checkInCount: 5,
+            lastCheckIn: new Date('2024-12-01'),
+            registeredAt: new Date('2024-01-01'),
+          },
+          {
+            userId: '507f1f77bcf86cd799439012',
+            username: 'inactiveuser',
+            email: 'inactive@example.com',
+            checkInCount: 0,
+            lastCheckIn: null,
+            registeredAt: new Date('2024-06-01'),
+          },
+        ],
+      };
+
+      (reportingService.getAllUsersStats as jest.Mock).mockResolvedValue(mockStats);
+
+      // Act
+      await getAdminStats(mockReq as Request, mockRes as Response, mockNext);
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        success: true,
+        data: mockStats,
+      });
+    });
+  });
+
+  describe('getMyStats', () => {
+    it('should return user statistics successfully', async () => {
+      // Arrange
+      const userId = '507f1f77bcf86cd799439011';
+      mockReq.user = { id: userId } as Express.User;
+
+      const mockUserStats = {
+        userId,
+        username: 'testuser',
+        email: 'test@example.com',
+        checkInCount: 25,
+        lastCheckIn: new Date('2024-12-05'),
+        registeredAt: new Date('2024-01-01'),
+        firstCheckIn: new Date('2024-06-01'),
+      };
+
+      (reportingService.getUserStats as jest.Mock).mockResolvedValue(mockUserStats);
+
+      // Act
+      await getMyStats(mockReq as Request, mockRes as Response, mockNext);
+
+      // Assert
+      expect(reportingService.getUserStats).toHaveBeenCalledWith(userId);
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        success: true,
+        data: mockUserStats,
+      });
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('should return 404 when user not found', async () => {
+      // Arrange
+      const userId = '507f1f77bcf86cd799439011';
+      mockReq.user = { id: userId } as Express.User;
+
+      (reportingService.getUserStats as jest.Mock).mockResolvedValue(null);
+
+      // Act
+      await getMyStats(mockReq as Request, mockRes as Response, mockNext);
+
+      // Assert
+      expect(reportingService.getUserStats).toHaveBeenCalledWith(userId);
+      expect(mockRes.status).toHaveBeenCalledWith(404);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        success: false,
+        error: 'User not found',
+      });
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('should handle service errors and call next', async () => {
+      // Arrange
+      const userId = '507f1f77bcf86cd799439011';
+      mockReq.user = { id: userId } as Express.User;
+
+      const error = new Error('Database error');
+      (reportingService.getUserStats as jest.Mock).mockRejectedValue(error);
+
+      // Act
+      await getMyStats(mockReq as Request, mockRes as Response, mockNext);
+
+      // Assert
+      expect(reportingService.getUserStats).toHaveBeenCalledWith(userId);
+      expect(mockNext).toHaveBeenCalledWith(error);
+      expect(mockRes.status).not.toHaveBeenCalled();
+      expect(mockRes.json).not.toHaveBeenCalled();
+    });
+
+    it('should return stats for user with no check-ins', async () => {
+      // Arrange
+      const userId = '507f1f77bcf86cd799439011';
+      mockReq.user = { id: userId } as Express.User;
+
+      const mockUserStats = {
+        userId,
+        username: 'newuser',
+        email: 'new@example.com',
+        checkInCount: 0,
+        lastCheckIn: null,
+        registeredAt: new Date('2024-12-01'),
+        firstCheckIn: null,
+      };
+
+      (reportingService.getUserStats as jest.Mock).mockResolvedValue(mockUserStats);
+
+      // Act
+      await getMyStats(mockReq as Request, mockRes as Response, mockNext);
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        success: true,
+        data: mockUserStats,
+      });
+    });
+
+    it('should extract user id from req.user object', async () => {
+      // Arrange
+      const userId = '507f1f77bcf86cd799439011';
+      mockReq.user = {
+        id: userId,
+        username: 'testuser',
+        email: 'test@example.com',
+      };
+
+      const mockUserStats = {
+        userId,
+        username: 'testuser',
+        email: 'test@example.com',
+        checkInCount: 10,
+        lastCheckIn: new Date('2024-12-01'),
+        registeredAt: new Date('2024-01-01'),
+        firstCheckIn: new Date('2024-06-01'),
+      };
+
+      (reportingService.getUserStats as jest.Mock).mockResolvedValue(mockUserStats);
+
+      // Act
+      await getMyStats(mockReq as Request, mockRes as Response, mockNext);
+
+      // Assert
+      expect(reportingService.getUserStats).toHaveBeenCalledWith(userId);
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+    });
+
+    it('should handle missing user id gracefully', async () => {
+      // Arrange
+      mockReq.user = { id: undefined } as any;
+
+      (reportingService.getUserStats as jest.Mock).mockResolvedValue(null);
+
+      // Act
+      await getMyStats(mockReq as Request, mockRes as Response, mockNext);
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(404);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        success: false,
+        error: 'User not found',
+      });
+    });
+
+    it('should return stats with valid check-in dates', async () => {
+      // Arrange
+      const userId = '507f1f77bcf86cd799439011';
+      mockReq.user = { id: userId } as Express.User;
+
+      const firstCheckInDate = new Date('2024-01-15');
+      const lastCheckInDate = new Date('2024-12-08');
+
+      const mockUserStats = {
+        userId,
+        username: 'activeuser',
+        email: 'active@example.com',
+        checkInCount: 100,
+        lastCheckIn: lastCheckInDate,
+        registeredAt: new Date('2024-01-01'),
+        firstCheckIn: firstCheckInDate,
+      };
+
+      (reportingService.getUserStats as jest.Mock).mockResolvedValue(mockUserStats);
+
+      // Act
+      await getMyStats(mockReq as Request, mockRes as Response, mockNext);
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      const responseData = (mockRes.json as jest.Mock).mock.calls[0][0];
+      expect(responseData.data.firstCheckIn).toEqual(firstCheckInDate);
+      expect(responseData.data.lastCheckIn).toEqual(lastCheckInDate);
+    });
+
+    it('should handle database timeout errors', async () => {
+      // Arrange
+      const userId = '507f1f77bcf86cd799439011';
+      mockReq.user = { id: userId } as Express.User;
+
+      const error = new Error('Query timeout');
+      (reportingService.getUserStats as jest.Mock).mockRejectedValue(error);
+
+      // Act
+      await getMyStats(mockReq as Request, mockRes as Response, mockNext);
+
+      // Assert
+      expect(mockNext).toHaveBeenCalledWith(error);
+      expect(mockRes.status).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -304,6 +304,7 @@ export async function verifyMagicLink(
           email: user.email,
           notificationTimes: user.notificationTimes,
           notificationsEnabled: user.notificationsEnabled,
+          isAdmin: user.isAdmin,
           createdAt: user.createdAt,
         },
         token: jwtToken,

--- a/backend/src/controllers/passkeyController.ts
+++ b/backend/src/controllers/passkeyController.ts
@@ -353,6 +353,7 @@ export async function verifyAuthentication(
           email: user.email,
           notificationTimes: user.notificationTimes,
           notificationsEnabled: user.notificationsEnabled,
+          isAdmin: user.isAdmin,
           createdAt: user.createdAt,
         },
         token: jwtToken,

--- a/backend/src/controllers/reportingController.ts
+++ b/backend/src/controllers/reportingController.ts
@@ -36,11 +36,7 @@ export async function getAdminStats(
  * GET /api/reporting/my-stats
  * Returns check-in statistics for the authenticated user
  */
-export async function getMyStats(
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<void> {
+export async function getMyStats(req: Request, res: Response, next: NextFunction): Promise<void> {
   try {
     const userId = (req.user as { id: string })!.id;
 

--- a/backend/src/controllers/reportingController.ts
+++ b/backend/src/controllers/reportingController.ts
@@ -1,0 +1,72 @@
+import { Request, Response, NextFunction } from 'express';
+import { getAllUsersStats, getUserStats } from '../services/reportingService';
+import { logger } from '../utils/logger';
+
+/**
+ * GET /api/reporting/admin/all-users
+ * Returns system-wide statistics including all users and their check-in data
+ * (Admin only)
+ */
+export async function getAdminStats(
+  _req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    logger.info('Fetching admin statistics');
+
+    const stats = await getAllUsersStats();
+
+    logger.info('Admin statistics completed', {
+      totalUsers: stats.totalUsers,
+      totalCheckIns: stats.totalCheckIns,
+    });
+
+    res.status(200).json({
+      success: true,
+      data: stats,
+    });
+  } catch (error) {
+    logger.error('Error fetching admin statistics', { error });
+    next(error);
+  }
+}
+
+/**
+ * GET /api/reporting/my-stats
+ * Returns check-in statistics for the authenticated user
+ */
+export async function getMyStats(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const userId = (req.user as { id: string })!.id;
+
+    logger.info('Fetching user statistics', { userId });
+
+    const stats = await getUserStats(userId);
+
+    if (!stats) {
+      res.status(404).json({
+        success: false,
+        error: 'User not found',
+      });
+      return;
+    }
+
+    logger.info('User statistics completed', {
+      userId,
+      checkInCount: stats.checkInCount,
+    });
+
+    res.status(200).json({
+      success: true,
+      data: stats,
+    });
+  } catch (error) {
+    logger.error('Error fetching user statistics', { error });
+    next(error);
+  }
+}

--- a/backend/src/models/User.ts
+++ b/backend/src/models/User.ts
@@ -8,6 +8,7 @@ export interface IUser extends Document {
   email: string;
   notificationTimes: string[];
   notificationsEnabled: boolean;
+  isAdmin: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -46,6 +47,10 @@ const userSchema = new Schema<IUser>(
     notificationsEnabled: {
       type: Boolean,
       default: true,
+    },
+    isAdmin: {
+      type: Boolean,
+      default: false,
     },
   },
   {

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -3,6 +3,7 @@ import authRoutes from './authRoutes';
 import checkinRoutes from './checkinRoutes';
 import analysisRoutes from './analysisRoutes';
 import userRoutes from './userRoutes';
+import reportingRoutes from './reportingRoutes';
 
 const router = Router();
 
@@ -16,5 +17,6 @@ router.use('/auth', authRoutes);
 router.use('/checkins', checkinRoutes);
 router.use('/analysis', analysisRoutes);
 router.use('/user', userRoutes);
+router.use('/reporting', reportingRoutes);
 
 export default router;

--- a/backend/src/routes/reportingRoutes.ts
+++ b/backend/src/routes/reportingRoutes.ts
@@ -1,0 +1,25 @@
+import { Router } from 'express';
+import { authenticate, requireAdmin } from '../middleware/auth';
+import { getAdminStats, getMyStats } from '../controllers/reportingController';
+
+const router = Router();
+
+/**
+ * All reporting routes require authentication
+ */
+router.use(authenticate);
+
+/**
+ * GET /api/reporting/my-stats
+ * Get check-in statistics for the authenticated user
+ */
+router.get('/my-stats', getMyStats);
+
+/**
+ * GET /api/reporting/admin/all-users
+ * Get system-wide statistics for all users
+ * (Admin only - requires isAdmin = true)
+ */
+router.get('/admin/all-users', requireAdmin, getAdminStats);
+
+export default router;

--- a/backend/src/services/__tests__/reportingService.test.ts
+++ b/backend/src/services/__tests__/reportingService.test.ts
@@ -1,0 +1,479 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import mongoose from 'mongoose';
+import { getAllUsersStats, getUserStats } from '../reportingService';
+import User from '../../models/User';
+import CheckIn from '../../models/CheckIn';
+
+// Mock the models
+jest.mock('../../models/User');
+jest.mock('../../models/CheckIn');
+
+describe('Reporting Service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getAllUsersStats', () => {
+    it('should return statistics for all users with check-ins', async () => {
+      // Arrange
+      const mockUsers: any[] = [
+        {
+          _id: new mongoose.Types.ObjectId('507f1f77bcf86cd799439011'),
+          username: 'user1',
+          email: 'user1@example.com',
+          createdAt: new Date('2024-01-01'),
+        },
+        {
+          _id: new mongoose.Types.ObjectId('507f1f77bcf86cd799439012'),
+          username: 'user2',
+          email: 'user2@example.com',
+          createdAt: new Date('2024-01-02'),
+        },
+      ];
+
+      const mockCheckInStats: any[] = [
+        {
+          _id: new mongoose.Types.ObjectId('507f1f77bcf86cd799439011'),
+          count: 5,
+          lastCheckIn: new Date('2024-12-01'),
+        },
+        {
+          _id: new mongoose.Types.ObjectId('507f1f77bcf86cd799439012'),
+          count: 3,
+          lastCheckIn: new Date('2024-12-02'),
+        },
+      ];
+
+      (User.find as any).mockReturnValue({
+        sort: (jest.fn() as any).mockReturnThis(),
+        lean: (jest.fn() as any).mockResolvedValue(mockUsers),
+      });
+
+      (CheckIn.aggregate as any).mockResolvedValue(mockCheckInStats);
+
+      // Act
+      const result = await getAllUsersStats();
+
+      // Assert
+      expect(result.totalUsers).toBe(2);
+      expect(result.totalCheckIns).toBe(8); // 5 + 3
+      expect(result.users).toHaveLength(2);
+      expect(result.users[0]).toEqual({
+        userId: '507f1f77bcf86cd799439011',
+        username: 'user1',
+        email: 'user1@example.com',
+        checkInCount: 5,
+        lastCheckIn: new Date('2024-12-01'),
+        registeredAt: new Date('2024-01-01'),
+      });
+      expect(result.users[1]).toEqual({
+        userId: '507f1f77bcf86cd799439012',
+        username: 'user2',
+        email: 'user2@example.com',
+        checkInCount: 3,
+        lastCheckIn: new Date('2024-12-02'),
+        registeredAt: new Date('2024-01-02'),
+      });
+    });
+
+    it('should handle users with no check-ins', async () => {
+      // Arrange
+      const mockUsers: any[] = [
+        {
+          _id: new mongoose.Types.ObjectId('507f1f77bcf86cd799439011'),
+          username: 'newuser',
+          email: 'newuser@example.com',
+          createdAt: new Date('2024-12-01'),
+        },
+      ];
+
+      (User.find as any).mockReturnValue({
+        sort: (jest.fn() as any).mockReturnThis(),
+        lean: (jest.fn() as any).mockResolvedValue(mockUsers),
+      });
+
+      (CheckIn.aggregate as any).mockResolvedValue([]);
+
+      // Act
+      const result = await getAllUsersStats();
+
+      // Assert
+      expect(result.totalUsers).toBe(1);
+      expect(result.totalCheckIns).toBe(0);
+      expect(result.users).toHaveLength(1);
+      expect(result.users[0]).toEqual({
+        userId: '507f1f77bcf86cd799439011',
+        username: 'newuser',
+        email: 'newuser@example.com',
+        checkInCount: 0,
+        lastCheckIn: null,
+        registeredAt: new Date('2024-12-01'),
+      });
+    });
+
+    it('should handle empty database (no users)', async () => {
+      // Arrange
+      (User.find as any).mockReturnValue({
+        sort: (jest.fn() as any).mockReturnThis(),
+        lean: (jest.fn() as any).mockResolvedValue([]),
+      });
+
+      (CheckIn.aggregate as any).mockResolvedValue([]);
+
+      // Act
+      const result = await getAllUsersStats();
+
+      // Assert
+      expect(result.totalUsers).toBe(0);
+      expect(result.totalCheckIns).toBe(0);
+      expect(result.users).toHaveLength(0);
+    });
+
+    it('should handle mixed case with some users having check-ins and others not', async () => {
+      // Arrange
+      const mockUsers: any[] = [
+        {
+          _id: new mongoose.Types.ObjectId('507f1f77bcf86cd799439011'),
+          username: 'activeuser',
+          email: 'active@example.com',
+          createdAt: new Date('2024-01-01'),
+        },
+        {
+          _id: new mongoose.Types.ObjectId('507f1f77bcf86cd799439012'),
+          username: 'inactiveuser',
+          email: 'inactive@example.com',
+          createdAt: new Date('2024-01-02'),
+        },
+        {
+          _id: new mongoose.Types.ObjectId('507f1f77bcf86cd799439013'),
+          username: 'anotheractive',
+          email: 'another@example.com',
+          createdAt: new Date('2024-01-03'),
+        },
+      ];
+
+      const mockCheckInStats: any[] = [
+        {
+          _id: new mongoose.Types.ObjectId('507f1f77bcf86cd799439011'),
+          count: 10,
+          lastCheckIn: new Date('2024-12-05'),
+        },
+        {
+          _id: new mongoose.Types.ObjectId('507f1f77bcf86cd799439013'),
+          count: 2,
+          lastCheckIn: new Date('2024-12-03'),
+        },
+      ];
+
+      (User.find as any).mockReturnValue({
+        sort: (jest.fn() as any).mockReturnThis(),
+        lean: (jest.fn() as any).mockResolvedValue(mockUsers),
+      });
+
+      (CheckIn.aggregate as any).mockResolvedValue(mockCheckInStats);
+
+      // Act
+      const result = await getAllUsersStats();
+
+      // Assert
+      expect(result.totalUsers).toBe(3);
+      expect(result.totalCheckIns).toBe(12); // 10 + 2
+      expect(result.users).toHaveLength(3);
+
+      // Check active user
+      const activeUser = result.users.find((u) => u.username === 'activeuser');
+      expect(activeUser?.checkInCount).toBe(10);
+      expect(activeUser?.lastCheckIn).toEqual(new Date('2024-12-05'));
+
+      // Check inactive user
+      const inactiveUser = result.users.find((u) => u.username === 'inactiveuser');
+      expect(inactiveUser?.checkInCount).toBe(0);
+      expect(inactiveUser?.lastCheckIn).toBeNull();
+
+      // Check another active user
+      const anotherActive = result.users.find((u) => u.username === 'anotheractive');
+      expect(anotherActive?.checkInCount).toBe(2);
+    });
+
+    it('should sort users by creation date descending', async () => {
+      // Arrange
+      const mockUsers: any[] = [
+        {
+          _id: new mongoose.Types.ObjectId('507f1f77bcf86cd799439013'),
+          username: 'newest',
+          email: 'newest@example.com',
+          createdAt: new Date('2024-12-03'),
+        },
+        {
+          _id: new mongoose.Types.ObjectId('507f1f77bcf86cd799439012'),
+          username: 'middle',
+          email: 'middle@example.com',
+          createdAt: new Date('2024-12-02'),
+        },
+        {
+          _id: new mongoose.Types.ObjectId('507f1f77bcf86cd799439011'),
+          username: 'oldest',
+          email: 'oldest@example.com',
+          createdAt: new Date('2024-12-01'),
+        },
+      ];
+
+      (User.find as any).mockReturnValue({
+        sort: (jest.fn() as any).mockReturnThis(),
+        lean: (jest.fn() as any).mockResolvedValue(mockUsers),
+      });
+
+      (CheckIn.aggregate as any).mockResolvedValue([]);
+
+      // Act
+      await getAllUsersStats();
+
+      // Assert
+      const sortCall = (User.find as any).mock.results[0].value.sort;
+      expect(sortCall).toHaveBeenCalledWith({ createdAt: -1 });
+    });
+  });
+
+  describe('getUserStats', () => {
+    const userId = new mongoose.Types.ObjectId('507f1f77bcf86cd799439011');
+
+    it('should return stats for user with check-ins', async () => {
+      // Arrange
+      const mockUser: any = {
+        _id: userId,
+        username: 'testuser',
+        email: 'test@example.com',
+        createdAt: new Date('2024-01-01'),
+      };
+
+      const firstCheckIn: any = { timestamp: new Date('2024-06-01') };
+      const lastCheckIn: any = { timestamp: new Date('2024-12-01') };
+
+      (User.findById as any).mockReturnValue({
+        lean: (jest.fn() as any).mockResolvedValue(mockUser),
+      });
+
+      (CheckIn.countDocuments as any).mockResolvedValue(15);
+
+      (CheckIn.findOne as any)
+        .mockReturnValueOnce({
+          sort: (jest.fn() as any).mockReturnThis(),
+          select: (jest.fn() as any).mockReturnThis(),
+          lean: (jest.fn() as any).mockResolvedValue(firstCheckIn),
+        })
+        .mockReturnValueOnce({
+          sort: (jest.fn() as any).mockReturnThis(),
+          select: (jest.fn() as any).mockReturnThis(),
+          lean: (jest.fn() as any).mockResolvedValue(lastCheckIn),
+        });
+
+      // Act
+      const result = await getUserStats(userId);
+
+      // Assert
+      expect(result).toEqual({
+        userId: userId.toString(),
+        username: 'testuser',
+        email: 'test@example.com',
+        checkInCount: 15,
+        lastCheckIn: new Date('2024-12-01'),
+        registeredAt: new Date('2024-01-01'),
+        firstCheckIn: new Date('2024-06-01'),
+      });
+    });
+
+    it('should return null when user does not exist', async () => {
+      // Arrange
+      (User.findById as any).mockReturnValue({
+        lean: (jest.fn() as any).mockResolvedValue(null),
+      });
+
+      // Act
+      const result = await getUserStats(userId);
+
+      // Assert
+      expect(result).toBeNull();
+      expect(CheckIn.countDocuments).not.toHaveBeenCalled();
+    });
+
+    it('should handle user with no check-ins', async () => {
+      // Arrange
+      const mockUser: any = {
+        _id: userId,
+        username: 'newuser',
+        email: 'new@example.com',
+        createdAt: new Date('2024-12-01'),
+      };
+
+      (User.findById as any).mockReturnValue({
+        lean: (jest.fn() as any).mockResolvedValue(mockUser),
+      });
+
+      (CheckIn.countDocuments as any).mockResolvedValue(0);
+
+      (CheckIn.findOne as any)
+        .mockReturnValueOnce({
+          sort: (jest.fn() as any).mockReturnThis(),
+          select: (jest.fn() as any).mockReturnThis(),
+          lean: (jest.fn() as any).mockResolvedValue(null),
+        })
+        .mockReturnValueOnce({
+          sort: (jest.fn() as any).mockReturnThis(),
+          select: (jest.fn() as any).mockReturnThis(),
+          lean: (jest.fn() as any).mockResolvedValue(null),
+        });
+
+      // Act
+      const result = await getUserStats(userId);
+
+      // Assert
+      expect(result).toEqual({
+        userId: userId.toString(),
+        username: 'newuser',
+        email: 'new@example.com',
+        checkInCount: 0,
+        lastCheckIn: null,
+        registeredAt: new Date('2024-12-01'),
+        firstCheckIn: null,
+      });
+    });
+
+    it('should handle user with single check-in', async () => {
+      // Arrange
+      const mockUser: any = {
+        _id: userId,
+        username: 'singleuser',
+        email: 'single@example.com',
+        createdAt: new Date('2024-01-01'),
+      };
+
+      const singleCheckIn: any = { timestamp: new Date('2024-06-15') };
+
+      (User.findById as any).mockReturnValue({
+        lean: (jest.fn() as any).mockResolvedValue(mockUser),
+      });
+
+      (CheckIn.countDocuments as any).mockResolvedValue(1);
+
+      (CheckIn.findOne as any)
+        .mockReturnValueOnce({
+          sort: (jest.fn() as any).mockReturnThis(),
+          select: (jest.fn() as any).mockReturnThis(),
+          lean: (jest.fn() as any).mockResolvedValue(singleCheckIn),
+        })
+        .mockReturnValueOnce({
+          sort: (jest.fn() as any).mockReturnThis(),
+          select: (jest.fn() as any).mockReturnThis(),
+          lean: (jest.fn() as any).mockResolvedValue(singleCheckIn),
+        });
+
+      // Act
+      const result = await getUserStats(userId);
+
+      // Assert
+      expect(result?.checkInCount).toBe(1);
+      expect(result?.firstCheckIn).toEqual(new Date('2024-06-15'));
+      expect(result?.lastCheckIn).toEqual(new Date('2024-06-15'));
+    });
+
+    it('should accept userId as string', async () => {
+      // Arrange
+      const userIdString = '507f1f77bcf86cd799439011';
+      const mockUser: any = {
+        _id: new mongoose.Types.ObjectId(userIdString),
+        username: 'testuser',
+        email: 'test@example.com',
+        createdAt: new Date('2024-01-01'),
+      };
+
+      (User.findById as any).mockReturnValue({
+        lean: (jest.fn() as any).mockResolvedValue(mockUser),
+      });
+
+      (CheckIn.countDocuments as any).mockResolvedValue(5);
+
+      (CheckIn.findOne as any)
+        .mockReturnValueOnce({
+          sort: (jest.fn() as any).mockReturnThis(),
+          select: (jest.fn() as any).mockReturnThis(),
+          lean: (jest.fn() as any).mockResolvedValue({ timestamp: new Date('2024-06-01') }),
+        })
+        .mockReturnValueOnce({
+          sort: (jest.fn() as any).mockReturnThis(),
+          select: (jest.fn() as any).mockReturnThis(),
+          lean: (jest.fn() as any).mockResolvedValue({ timestamp: new Date('2024-12-01') }),
+        });
+
+      // Act
+      const result = await getUserStats(userIdString);
+
+      // Assert
+      expect(result).not.toBeNull();
+      expect(result?.userId).toBe(userIdString);
+      expect(User.findById).toHaveBeenCalledWith(userIdString);
+    });
+
+    it('should query check-ins with correct sorting', async () => {
+      // Arrange
+      const mockUser: any = {
+        _id: userId,
+        username: 'testuser',
+        email: 'test@example.com',
+        createdAt: new Date('2024-01-01'),
+      };
+
+      const mockSort = (jest.fn() as any).mockReturnThis();
+      const mockSelect = (jest.fn() as any).mockReturnThis();
+      const mockLean = (jest.fn() as any).mockResolvedValue({ timestamp: new Date() });
+
+      (User.findById as any).mockReturnValue({
+        lean: (jest.fn() as any).mockResolvedValue(mockUser),
+      });
+
+      (CheckIn.countDocuments as any).mockResolvedValue(5);
+
+      (CheckIn.findOne as any).mockReturnValue({
+        sort: mockSort,
+        select: mockSelect,
+        lean: mockLean,
+      });
+
+      // Act
+      await getUserStats(userId);
+
+      // Assert
+      expect(CheckIn.findOne).toHaveBeenCalledWith({ userId });
+      expect(mockSort).toHaveBeenCalledWith({ timestamp: 1 }); // First check-in (ascending)
+      expect(mockSort).toHaveBeenCalledWith({ timestamp: -1 }); // Last check-in (descending)
+      expect(mockSelect).toHaveBeenCalledWith('timestamp');
+    });
+
+    it('should count check-ins for correct user', async () => {
+      // Arrange
+      const mockUser: any = {
+        _id: userId,
+        username: 'testuser',
+        email: 'test@example.com',
+        createdAt: new Date('2024-01-01'),
+      };
+
+      (User.findById as any).mockReturnValue({
+        lean: (jest.fn() as any).mockResolvedValue(mockUser),
+      });
+
+      (CheckIn.countDocuments as any).mockResolvedValue(10);
+
+      (CheckIn.findOne as any).mockReturnValue({
+        sort: (jest.fn() as any).mockReturnThis(),
+        select: (jest.fn() as any).mockReturnThis(),
+        lean: (jest.fn() as any).mockResolvedValue(null),
+      });
+
+      // Act
+      await getUserStats(userId);
+
+      // Assert
+      expect(CheckIn.countDocuments).toHaveBeenCalledWith({ userId });
+    });
+  });
+});

--- a/backend/src/services/reportingService.ts
+++ b/backend/src/services/reportingService.ts
@@ -1,0 +1,134 @@
+/**
+ * Reporting Service Module
+ *
+ * Provides user registration and check-in statistics for admin reporting
+ * and individual user stats.
+ */
+
+import { Types } from 'mongoose';
+import User from '../models/User';
+import CheckIn from '../models/CheckIn';
+
+/**
+ * User statistics interface
+ */
+export interface UserStats {
+  userId: string;
+  username: string;
+  email: string;
+  checkInCount: number;
+  lastCheckIn: Date | null;
+  registeredAt: Date;
+}
+
+/**
+ * System-wide statistics interface
+ */
+export interface SystemStats {
+  totalUsers: number;
+  totalCheckIns: number;
+  users: UserStats[];
+}
+
+/**
+ * Individual user statistics interface
+ */
+export interface IndividualUserStats {
+  userId: string;
+  username: string;
+  email: string;
+  checkInCount: number;
+  lastCheckIn: Date | null;
+  registeredAt: Date;
+  firstCheckIn: Date | null;
+}
+
+/**
+ * Get statistics for all users in the system (admin only)
+ *
+ * Returns comprehensive statistics including user count, total check-ins,
+ * and detailed stats for each user.
+ *
+ * @returns System-wide statistics with all user data
+ */
+export async function getAllUsersStats(): Promise<SystemStats> {
+  // Get all users
+  const users = await User.find().sort({ createdAt: -1 }).lean();
+
+  // Get check-in statistics for all users using aggregation
+  const checkInStats = await CheckIn.aggregate([
+    {
+      $group: {
+        _id: '$userId',
+        count: { $sum: 1 },
+        lastCheckIn: { $max: '$timestamp' },
+      },
+    },
+  ]);
+
+  // Create a map of userId to check-in stats for quick lookup
+  const statsMap = new Map(
+    checkInStats.map((stat) => [stat._id.toString(), { count: stat.count, lastCheckIn: stat.lastCheckIn }])
+  );
+
+  // Combine user data with check-in stats
+  const userStats: UserStats[] = users.map((user) => {
+    const stats = statsMap.get(user._id.toString());
+    return {
+      userId: user._id.toString(),
+      username: user.username,
+      email: user.email,
+      checkInCount: stats?.count || 0,
+      lastCheckIn: stats?.lastCheckIn || null,
+      registeredAt: user.createdAt,
+    };
+  });
+
+  // Calculate total check-ins
+  const totalCheckIns = checkInStats.reduce((sum, stat) => sum + stat.count, 0);
+
+  return {
+    totalUsers: users.length,
+    totalCheckIns,
+    users: userStats,
+  };
+}
+
+/**
+ * Get statistics for a specific user
+ *
+ * Returns detailed statistics for the specified user including
+ * check-in count, first and last check-in dates.
+ *
+ * @param userId - The user's ID
+ * @returns Individual user statistics
+ */
+export async function getUserStats(
+  userId: string | Types.ObjectId
+): Promise<IndividualUserStats | null> {
+  // Get user data
+  const user = await User.findById(userId).lean();
+
+  if (!user) {
+    return null;
+  }
+
+  // Get check-in count
+  const checkInCount = await CheckIn.countDocuments({ userId });
+
+  // Get first and last check-in timestamps
+  const [firstCheckInDoc, lastCheckInDoc] = await Promise.all([
+    CheckIn.findOne({ userId }).sort({ timestamp: 1 }).select('timestamp').lean(),
+    CheckIn.findOne({ userId }).sort({ timestamp: -1 }).select('timestamp').lean(),
+  ]);
+
+  return {
+    userId: user._id.toString(),
+    username: user.username,
+    email: user.email,
+    checkInCount,
+    lastCheckIn: lastCheckInDoc?.timestamp || null,
+    registeredAt: user.createdAt,
+    firstCheckIn: firstCheckInDoc?.timestamp || null,
+  };
+}

--- a/backend/src/services/reportingService.ts
+++ b/backend/src/services/reportingService.ts
@@ -68,7 +68,10 @@ export async function getAllUsersStats(): Promise<SystemStats> {
 
   // Create a map of userId to check-in stats for quick lookup
   const statsMap = new Map(
-    checkInStats.map((stat) => [stat._id.toString(), { count: stat.count, lastCheckIn: stat.lastCheckIn }])
+    checkInStats.map((stat) => [
+      stat._id.toString(),
+      { count: stat.count, lastCheckIn: stat.lastCheckIn },
+    ])
   );
 
   // Combine user data with check-in stats

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import { ProtectedRoute } from './components/ProtectedRoute';
+import { AdminRoute } from './components/AdminRoute';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { useAuthStore } from './stores/authStore';
 import LoginPage from './pages/LoginPage';
@@ -12,6 +13,7 @@ import TrendsPage from './pages/TrendsPage';
 import SettingsPage from './pages/SettingsPage';
 import DeleteAccountPage from './pages/DeleteAccountPage';
 import DesignSystemPage from './pages/DesignSystemPage';
+import AdminDashboardPage from './pages/AdminDashboardPage';
 
 function App() {
   const restoreSession = useAuthStore((state) => state.restoreSession);
@@ -70,6 +72,16 @@ function App() {
             <ProtectedRoute>
               <DeleteAccountPage />
             </ProtectedRoute>
+          }
+        />
+
+        {/* Admin-only routes */}
+        <Route
+          path="/admin"
+          element={
+            <AdminRoute>
+              <AdminDashboardPage />
+            </AdminRoute>
           }
         />
 

--- a/frontend/src/components/AdminRoute.tsx
+++ b/frontend/src/components/AdminRoute.tsx
@@ -1,0 +1,29 @@
+import { Navigate } from 'react-router';
+import { useAuthStore } from '../stores/authStore';
+
+interface AdminRouteProps {
+  children: React.ReactNode;
+}
+
+export function AdminRoute({ children }: AdminRouteProps) {
+  const isLoading = useAuthStore((state) => state.isLoading);
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated());
+  const user = useAuthStore((state) => state.user);
+
+  // Wait for session restoration to complete before checking authentication
+  if (isLoading) {
+    return null; // Or a loading spinner if desired
+  }
+
+  if (!isAuthenticated) {
+    // Redirect to login if not authenticated
+    return <Navigate to="/login" replace />;
+  }
+
+  if (!user?.isAdmin) {
+    // Redirect to dashboard if not an admin
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -16,7 +16,7 @@ export interface HeaderProps {
   /**
    * Which page is currently active (to hide that nav link)
    */
-  currentPage?: 'dashboard' | 'trends' | 'settings' | 'checkin';
+  currentPage?: 'dashboard' | 'trends' | 'settings' | 'checkin' | 'admin';
 }
 
 /**
@@ -72,6 +72,17 @@ export function Header({ title, subtitle, currentPage }: HeaderProps) {
               >
                 <span className="hidden sm:inline">Trends</span>
                 <span className="sm:hidden">📈</span>
+              </Button>
+            )}
+            {user?.isAdmin && currentPage !== 'admin' && (
+              <Button
+                onClick={() => navigate('/admin')}
+                variant="secondary"
+                size="small"
+                className="whitespace-nowrap bg-white/10 border-white/30 text-white hover:bg-white/20 hover:text-white"
+              >
+                <span className="hidden sm:inline">Admin</span>
+                <span className="sm:hidden">🔐</span>
               </Button>
             )}
             <ProfileDropdown />

--- a/frontend/src/components/UserStatsCard.tsx
+++ b/frontend/src/components/UserStatsCard.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from 'react';
+import { reportingApi } from '../services/api';
+import type { IndividualUserStats } from '../services/api';
+import { Alert } from './ui/Alert';
+
+export function UserStatsCard() {
+  const [stats, setStats] = useState<IndividualUserStats | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchStats = async () => {
+      try {
+        setIsLoading(true);
+        setError(null);
+
+        const response = await reportingApi.getMyStats();
+
+        if (response.success) {
+          setStats(response.data);
+        }
+      } catch (err) {
+        console.error('Failed to fetch user stats:', err);
+        setError('Failed to load your statistics.');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchStats();
+  }, []);
+
+  const formatDate = (dateString: string | null) => {
+    if (!dateString) return 'Never';
+    const date = new Date(dateString);
+    return date.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  const formatShortDate = (dateString: string | null) => {
+    if (!dateString) return 'Never';
+    const date = new Date(dateString);
+    return date.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  };
+
+  if (error) {
+    return <Alert type="error">{error}</Alert>;
+  }
+
+  if (isLoading) {
+    return (
+      <div className="bg-white rounded-lg shadow p-6">
+        <div className="animate-pulse">
+          <div className="h-6 bg-gray-200 rounded w-1/3 mb-4"></div>
+          <div className="space-y-3">
+            <div className="h-4 bg-gray-200 rounded w-1/2"></div>
+            <div className="h-4 bg-gray-200 rounded w-2/3"></div>
+            <div className="h-4 bg-gray-200 rounded w-1/2"></div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!stats) {
+    return null;
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow p-6">
+      <h2 className="text-xl font-semibold text-gray-900 mb-4">Your Activity</h2>
+
+      <div className="space-y-4">
+        {/* Total Check-ins */}
+        <div className="flex items-center justify-between py-3 border-b border-gray-100">
+          <span className="text-gray-600">Total Check-ins</span>
+          <span className="text-2xl font-bold text-blue-600">{stats.checkInCount}</span>
+        </div>
+
+        {/* First Check-in */}
+        <div className="flex items-center justify-between py-3 border-b border-gray-100">
+          <span className="text-gray-600">First Check-in</span>
+          <span className="text-sm text-gray-900 font-medium">
+            {formatShortDate(stats.firstCheckIn)}
+          </span>
+        </div>
+
+        {/* Last Check-in */}
+        <div className="flex items-center justify-between py-3 border-b border-gray-100">
+          <span className="text-gray-600">Last Check-in</span>
+          <span className="text-sm text-gray-900 font-medium">
+            {formatDate(stats.lastCheckIn)}
+          </span>
+        </div>
+
+        {/* Member Since */}
+        <div className="flex items-center justify-between py-3">
+          <span className="text-gray-600">Member Since</span>
+          <span className="text-sm text-gray-900 font-medium">
+            {formatShortDate(stats.registeredAt)}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/AdminDashboardPage.tsx
+++ b/frontend/src/pages/AdminDashboardPage.tsx
@@ -1,0 +1,204 @@
+import { useEffect, useState } from 'react';
+import { reportingApi } from '../services/api';
+import type { SystemStats, UserStats } from '../services/api';
+import { Alert } from '../components/ui/Alert';
+import { Header } from '../components/Header';
+
+export default function AdminDashboardPage() {
+  const [stats, setStats] = useState<SystemStats | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [sortField, setSortField] = useState<keyof UserStats>('registeredAt');
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('desc');
+
+  useEffect(() => {
+    const fetchStats = async () => {
+      try {
+        setIsLoading(true);
+        setError(null);
+
+        const response = await reportingApi.getAdminStats();
+
+        if (response.success) {
+          setStats(response.data);
+        }
+      } catch (err) {
+        console.error('Failed to fetch admin stats:', err);
+        setError(
+          err instanceof Error && err.message.includes('403')
+            ? 'Access denied. Admin privileges required.'
+            : 'Failed to load admin statistics.'
+        );
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchStats();
+  }, []);
+
+  const handleSort = (field: keyof UserStats) => {
+    if (sortField === field) {
+      setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortField(field);
+      setSortDirection('desc');
+    }
+  };
+
+  const sortedUsers = stats?.users.slice().sort((a, b) => {
+    const aValue = a[sortField];
+    const bValue = b[sortField];
+
+    if (aValue === null) return 1;
+    if (bValue === null) return -1;
+
+    let comparison = 0;
+    if (typeof aValue === 'number' && typeof bValue === 'number') {
+      comparison = aValue - bValue;
+    } else if (typeof aValue === 'string' && typeof bValue === 'string') {
+      // For date strings, convert to Date for proper comparison
+      if (sortField === 'lastCheckIn' || sortField === 'registeredAt') {
+        const aDate = new Date(aValue);
+        const bDate = new Date(bValue);
+        comparison = aDate.getTime() - bDate.getTime();
+      } else {
+        comparison = aValue.localeCompare(bValue);
+      }
+    }
+
+    return sortDirection === 'asc' ? comparison : -comparison;
+  });
+
+  const formatDate = (dateString: string | null) => {
+    if (!dateString) return 'Never';
+    const date = new Date(dateString);
+    return date.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Header currentPage="admin" />
+
+      <main className="container mx-auto px-4 py-6 sm:py-8">
+        <div className="max-w-7xl mx-auto">
+          <h1 className="text-3xl font-bold text-gray-900 mb-6">Admin Dashboard</h1>
+
+          {error && <Alert type="error">{error}</Alert>}
+
+          {isLoading ? (
+            <div className="bg-white rounded-lg shadow p-8 text-center">
+              <div className="animate-pulse">
+                <div className="h-4 bg-gray-200 rounded w-1/4 mx-auto mb-4"></div>
+                <div className="h-4 bg-gray-200 rounded w-1/2 mx-auto"></div>
+              </div>
+            </div>
+          ) : (
+            stats && (
+              <>
+                {/* Summary Cards */}
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
+                  <div className="bg-white rounded-lg shadow p-6">
+                    <h2 className="text-sm font-medium text-gray-500 uppercase tracking-wide mb-2">
+                      Total Users
+                    </h2>
+                    <p className="text-4xl font-bold text-blue-600">{stats.totalUsers}</p>
+                  </div>
+
+                  <div className="bg-white rounded-lg shadow p-6">
+                    <h2 className="text-sm font-medium text-gray-500 uppercase tracking-wide mb-2">
+                      Total Check-ins
+                    </h2>
+                    <p className="text-4xl font-bold text-green-600">{stats.totalCheckIns}</p>
+                  </div>
+                </div>
+
+                {/* Users Table */}
+                <div className="bg-white rounded-lg shadow overflow-hidden">
+                  <div className="px-6 py-4 border-b border-gray-200">
+                    <h2 className="text-xl font-semibold text-gray-900">User Details</h2>
+                  </div>
+
+                  <div className="overflow-x-auto">
+                    <table className="min-w-full divide-y divide-gray-200">
+                      <thead className="bg-gray-50">
+                        <tr>
+                          <th
+                            className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100"
+                            onClick={() => handleSort('username')}
+                          >
+                            Username {sortField === 'username' && (sortDirection === 'asc' ? '↑' : '↓')}
+                          </th>
+                          <th
+                            className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100"
+                            onClick={() => handleSort('email')}
+                          >
+                            Email {sortField === 'email' && (sortDirection === 'asc' ? '↑' : '↓')}
+                          </th>
+                          <th
+                            className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100"
+                            onClick={() => handleSort('checkInCount')}
+                          >
+                            Check-ins{' '}
+                            {sortField === 'checkInCount' && (sortDirection === 'asc' ? '↑' : '↓')}
+                          </th>
+                          <th
+                            className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100"
+                            onClick={() => handleSort('lastCheckIn')}
+                          >
+                            Last Check-in{' '}
+                            {sortField === 'lastCheckIn' && (sortDirection === 'asc' ? '↑' : '↓')}
+                          </th>
+                          <th
+                            className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100"
+                            onClick={() => handleSort('registeredAt')}
+                          >
+                            Registered{' '}
+                            {sortField === 'registeredAt' && (sortDirection === 'asc' ? '↑' : '↓')}
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody className="bg-white divide-y divide-gray-200">
+                        {sortedUsers?.map((user) => (
+                          <tr key={user.userId} className="hover:bg-gray-50">
+                            <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                              {user.username}
+                            </td>
+                            <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                              {user.email}
+                            </td>
+                            <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                              {user.checkInCount}
+                            </td>
+                            <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                              {formatDate(user.lastCheckIn)}
+                            </td>
+                            <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                              {formatDate(user.registeredAt)}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+
+                  {(!sortedUsers || sortedUsers.length === 0) && (
+                    <div className="text-center py-12">
+                      <p className="text-gray-500">No users found</p>
+                    </div>
+                  )}
+                </div>
+              </>
+            )
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -12,6 +12,7 @@ import {
   getBrowserDeviceName,
 } from '../utils/passkeys';
 import { Header } from '../components/Header';
+import { UserStatsCard } from '../components/UserStatsCard';
 
 export default function SettingsPage() {
   const navigate = useNavigate();
@@ -218,6 +219,12 @@ export default function SettingsPage() {
                 </div>
               </div>
             </Card>
+          </section>
+
+          {/* User Activity Stats */}
+          <section>
+            <h2 className="text-2xl font-bold text-gray-900 mb-4">Your Activity</h2>
+            <UserStatsCard />
           </section>
 
           {/* Security */}

--- a/frontend/src/pages/__tests__/CheckInPage.test.tsx
+++ b/frontend/src/pages/__tests__/CheckInPage.test.tsx
@@ -67,6 +67,7 @@ describe('CheckInPage', () => {
     email: 'test@example.com',
     notificationTimes: ['08:00'],
     notificationsEnabled: true,
+    isAdmin: false,
     createdAt: '2024-01-01T00:00:00.000Z',
   };
 

--- a/frontend/src/pages/__tests__/TrendsPage.test.tsx
+++ b/frontend/src/pages/__tests__/TrendsPage.test.tsx
@@ -59,6 +59,7 @@ describe('TrendsPage', () => {
     email: 'test@example.com',
     notificationTimes: ['08:00'],
     notificationsEnabled: true,
+    isAdmin: false,
     createdAt: '2024-01-01T00:00:00.000Z',
   };
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -56,6 +56,7 @@ export interface User {
   email: string;
   notificationTimes: string[];
   notificationsEnabled: boolean;
+  isAdmin: boolean;
   createdAt: string;
 }
 
@@ -549,6 +550,57 @@ export const passkeysApi = {
       `/auth/passkeys/${id}`,
       { deviceName }
     );
+    return response.data;
+  },
+};
+
+// Reporting API types
+export interface UserStats {
+  userId: string;
+  username: string;
+  email: string;
+  checkInCount: number;
+  lastCheckIn: string | null;
+  registeredAt: string;
+}
+
+export interface SystemStats {
+  totalUsers: number;
+  totalCheckIns: number;
+  users: UserStats[];
+}
+
+export interface IndividualUserStats {
+  userId: string;
+  username: string;
+  email: string;
+  checkInCount: number;
+  lastCheckIn: string | null;
+  registeredAt: string;
+  firstCheckIn: string | null;
+}
+
+export interface SystemStatsResponse {
+  success: boolean;
+  data: SystemStats;
+}
+
+export interface IndividualStatsResponse {
+  success: boolean;
+  data: IndividualUserStats;
+}
+
+// Reporting API
+export const reportingApi = {
+  // Get stats for the authenticated user
+  getMyStats: async (): Promise<IndividualStatsResponse> => {
+    const response = await apiClient.get<IndividualStatsResponse>('/reporting/my-stats');
+    return response.data;
+  },
+
+  // Get system-wide stats for all users (admin only)
+  getAdminStats: async (): Promise<SystemStatsResponse> => {
+    const response = await apiClient.get<SystemStatsResponse>('/reporting/admin/all-users');
     return response.data;
   },
 };

--- a/frontend/src/stores/__tests__/authStore.test.ts
+++ b/frontend/src/stores/__tests__/authStore.test.ts
@@ -47,6 +47,7 @@ describe('authStore', () => {
         email: 'test@example.com',
         notificationTimes: ['08:00'],
         notificationsEnabled: true,
+        isAdmin: false,
         createdAt: '2024-01-01T00:00:00.000Z',
       };
       const mockToken = 'mock-jwt-token';
@@ -74,6 +75,7 @@ describe('authStore', () => {
         email: 'test@example.com',
         notificationTimes: ['08:00'],
         notificationsEnabled: true,
+        isAdmin: false,
         createdAt: '2024-01-01T00:00:00.000Z',
       };
       const mockToken = 'mock-jwt-token';
@@ -103,6 +105,7 @@ describe('authStore', () => {
             email: 'test@example.com',
             notificationTimes: ['08:00'],
             notificationsEnabled: true,
+            isAdmin: false,
             createdAt: '2024-01-01T00:00:00.000Z',
           },
           token: 'mock-token',
@@ -124,6 +127,7 @@ describe('authStore', () => {
         email: 'new@example.com',
         notificationTimes: ['08:00'],
         notificationsEnabled: true,
+        isAdmin: false,
         createdAt: '2024-01-01T00:00:00.000Z',
       };
       const mockToken = 'new-mock-token';
@@ -151,6 +155,7 @@ describe('authStore', () => {
         email: 'new@example.com',
         notificationTimes: ['08:00'],
         notificationsEnabled: true,
+        isAdmin: false,
         createdAt: '2024-01-01T00:00:00.000Z',
       };
       const mockToken = 'new-mock-token';
@@ -183,6 +188,7 @@ describe('authStore', () => {
             email: 'test@example.com',
             notificationTimes: ['08:00'],
             notificationsEnabled: true,
+            isAdmin: false,
             createdAt: '2024-01-01T00:00:00.000Z',
           },
           token: 'mock-token',
@@ -243,6 +249,7 @@ describe('authStore', () => {
         email: 'test@example.com',
         notificationTimes: ['08:00'],
         notificationsEnabled: true,
+        isAdmin: false,
         createdAt: '2024-01-01T00:00:00.000Z',
       };
       const mockToken = 'stored-token';
@@ -303,6 +310,7 @@ describe('authStore', () => {
             email: 'test@example.com',
             notificationTimes: ['08:00'],
             notificationsEnabled: true,
+            isAdmin: false,
             createdAt: '2024-01-01T00:00:00.000Z',
           },
           token: 'mock-token',
@@ -330,6 +338,7 @@ describe('authStore', () => {
           email: 'test@example.com',
           notificationTimes: ['08:00'],
           notificationsEnabled: true,
+          isAdmin: false,
           createdAt: '2024-01-01T00:00:00.000Z',
         },
         token: null,


### PR DESCRIPTION
## Summary

Implements a comprehensive reporting mechanism to track user registrations and check-in activity with role-based access control.

- **Admin View**: System-wide dashboard showing all users and their statistics
- **User View**: Individual statistics displayed in Settings page
- **Secure Access**: Role-based authorization with admin middleware

## Backend Changes

### User Model
- Added `isAdmin` boolean field (default: false)
- Updated authentication responses to include admin status

### Reporting Service
- `getAllUsersStats()` - Aggregates system-wide statistics using MongoDB pipelines
- `getUserStats()` - Returns individual user statistics with check-in metrics

### API Endpoints
- `GET /api/reporting/my-stats` - User's own statistics (authenticated users)
- `GET /api/reporting/admin/all-users` - All users statistics (admin only)

### Security
- Created `requireAdmin` middleware for admin route protection
- Returns 403 Forbidden for non-admin users
- Chain: `authenticate` → `requireAdmin` → controller

## Frontend Changes

### Admin Features
- **AdminDashboardPage** (`/admin`) - Sortable table with all user statistics
  - Total users and check-ins counts
  - Per-user breakdown: username, email, check-in count, last check-in, registration date
  - Click column headers to sort
- **AdminRoute** component - Protects admin-only pages, redirects non-admins to dashboard

### User Features
- **UserStatsCard** component - Displays individual activity metrics
  - Total check-ins
  - First and last check-in dates
  - Account registration date
- Added to SettingsPage for easy access

### Navigation
- Admin button appears in header for admin users
- Automatically hidden for regular users

## Statistics Provided

**Individual Users:**
- Total check-in count
- First check-in date
- Last check-in timestamp
- Account registration date

**Admins:**
- Total registered users
- Total check-ins across system
- Per-user breakdown with sortable columns

## Access Control

✅ Users can only view their own statistics  
✅ Admin endpoints return 403 for non-admin users  
✅ Frontend AdminRoute redirects non-admins  
✅ Backend middleware enforces authorization  

## Testing

- Updated all test mocks to include `isAdmin` field
- TypeScript checks passing
- All existing tests updated

## Related

Closes #186